### PR TITLE
Fixed Issue 3

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
+* text=auto
 *.sh text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Fixed it by adding a `.gitattributes` file that is responsible for maintaining `entrypoint.sh`'s line endings set to LF. Related to #3.